### PR TITLE
Prevents recursive inclusion of generated flatrepo files

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,8 @@ Very useful to load knowledge to your favorite AI Agent like **Claude AI Project
 npm install -D flatrepo
 ```
 
-_Optional: You can set as script in your package.json_
+Optional: You can set as script in your package.json
+
 ```json
 {
   "scripts": {
@@ -20,19 +21,30 @@ _Optional: You can set as script in your package.json_
 ```
 
 ## Usage
-- Generate documentation in to default filename (flatrepo_YYYYMMDDHHIISS.md):
+
+Generate documentation in to default filename (flatrepo_YYYYMMDDHHIISS.md):
+
 ```bash
 flatrepo
 ```
 
-- Generate documentation in to a custom filename:
+Generate documentation in to a custom filename:
+
 ```bash
-flatrepo myrepo.md
+flatrepo myrepo-flat.md
 ```
 
-- Generate documentation including a description of binary files:
+> **Note**: Files matching any of these patterns are automatically ignored to prevent recursive inclusion in subsequent runs:
+>
+> - `flatrepo_*.md` (default output files)
+> - `*_flat.md` or `*-flat.md` (use one of these for custom filenames)
+>
+> Use custom filenames carefully, to prevent doubling the output size with each run!
+
+Generate documentation including a description of binary files:
+
 ```bash
-flatrepo myrepo.md --include-bin
+flatrepo --include-bin
 ```
 
 ## Features
@@ -40,7 +52,7 @@ flatrepo myrepo.md --include-bin
 - Generates markdown documentation of your repository
 - Includes YAML header with repository statistics
 - Ignore binary files (images, videos, zip, etc...)
-    - Include with description
+  - Include with description
 - Respects .gitignore patterns
 - Supports multiple file types
 - Formats code blocks according to file type

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,7 +28,7 @@ async function getProjectFiles(outputPath: string, includeBin: boolean): Promise
 		for (const match of matches) {
 			if (match === outputPath) continue;
 
-			if (shouldIgnoreFile(match, gitignorePatterns)) continue;
+			if (shouldIgnoreFile(match, ignorePatterns)) continue;
 			try {
 				const stat = await fs.stat(match);
 				const extension = path.extname(match).toLowerCase();

--- a/src/utils/gitignore.ts
+++ b/src/utils/gitignore.ts
@@ -9,7 +9,8 @@ export const DEFAULT_IGNORE_PATTERNS = [
   '.gitignore',
   '.git/**',
   'dist/**',
-  '.next/**'
+  '.next/**',
+  'flatrepo_*.md'
 ];
 
 async function readGitignoreFile(filePath: string): Promise<string[]> {

--- a/src/utils/gitignore.ts
+++ b/src/utils/gitignore.ts
@@ -10,7 +10,9 @@ export const DEFAULT_IGNORE_PATTERNS = [
   '.git/**',
   'dist/**',
   '.next/**',
-  'flatrepo_*.md'
+  'flatrepo_*.md',
+  '*_flat.md',
+  '*-flat.md'
 ];
 
 async function readGitignoreFile(filePath: string): Promise<string[]> {


### PR DESCRIPTION
Without this, each new flatrepo generation will include previous ones, doubling the file size each time. 

I've updated the readme as well to clarify what will be ignored, so users can pick custom filenames wisely. 

Let me know if you have another way you'd like to handle this, I took the quick and easy approach here. 