### PR TITLE
feat: add directory option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ yarn-error.log*
 # typescript
 *.tsbuildinfo
 next-env.d.ts
+
+# build files
+dist

--- a/README.md
+++ b/README.md
@@ -35,6 +35,11 @@ flatrepo myrepo.md
 flatrepo myrepo.md --include-bin
 ```
 
+- Generate documentation for a specific directory:
+```bash
+flatrepo myrepo.md --dir src
+```
+
 ## Features
 
 - Generates markdown documentation of your repository

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -24,11 +24,16 @@ yargs(hideBin(process.argv))
         type: 'boolean',
         describe: 'Include binary files with description',
         default: false
+    })
+        .option('dir', {
+        type: 'string',
+        describe: 'Specific directory to document',
+        default: '.'
     });
 }, async (argv) => {
     const outputFile = argv.output || getDefaultFilename();
     try {
-        await generateDocs(outputFile, argv.includeBin);
+        await generateDocs(outputFile, argv.includeBin, argv.dir);
         console.log(`FlatRepo generated successfully at: ${outputFile}`);
     }
     catch (error) {

--- a/dist/cli.js
+++ b/dist/cli.js
@@ -1,46 +1,50 @@
 #!/usr/bin/env node
-import yargs from 'yargs';
-import { hideBin } from 'yargs/helpers';
-import { generateDocs } from './index.js';
+import yargs from "yargs";
+import { hideBin } from "yargs/helpers";
+import { generateDocs } from "./index.js";
 function getDefaultFilename() {
-    const now = new Date();
-    const year = now.getFullYear();
-    const month = String(now.getMonth() + 1).padStart(2, '0');
-    const day = String(now.getDate()).padStart(2, '0');
-    const hours = String(now.getHours()).padStart(2, '0');
-    const minutes = String(now.getMinutes()).padStart(2, '0');
-    const seconds = String(now.getSeconds()).padStart(2, '0');
-    return `flatrepo_${year}${month}${day}${hours}${minutes}${seconds}.md`;
+	const now = new Date();
+	const year = now.getFullYear();
+	const month = String(now.getMonth() + 1).padStart(2, "0");
+	const day = String(now.getDate()).padStart(2, "0");
+	const hours = String(now.getHours()).padStart(2, "0");
+	const minutes = String(now.getMinutes()).padStart(2, "0");
+	const seconds = String(now.getSeconds()).padStart(2, "0");
+	return `flatrepo_${year}${month}${day}${hours}${minutes}${seconds}.md`;
 }
 yargs(hideBin(process.argv))
-    .command('$0 [output]', 'Generate repository documentation', (yargs) => {
-    return yargs
-        .positional('output', {
-        describe: 'Output markdown file',
-        type: 'string',
-        default: getDefaultFilename()
-    })
-        .option('include-bin', {
-        type: 'boolean',
-        describe: 'Include binary files with description',
-        default: false
-    })
-        .option('dir', {
-        type: 'string',
-        describe: 'Specific directory to document',
-        default: '.'
-    });
-}, async (argv) => {
-    const outputFile = argv.output || getDefaultFilename();
-    try {
-        await generateDocs(outputFile, argv.includeBin, argv.dir);
-        console.log(`FlatRepo generated successfully at: ${outputFile}`);
-    }
-    catch (error) {
-        console.error('Error generating documentation:', error);
-        process.exit(1);
-    }
-})
-    .strict()
-    .help()
-    .parse();
+	.command(
+		"$0 [output]",
+		"Generate repository documentation",
+		(yargs) => {
+			return yargs
+				.positional("output", {
+					describe: "Output markdown file",
+					type: "string",
+					default: getDefaultFilename(),
+				})
+				.option("include-bin", {
+					type: "boolean",
+					describe: "Include binary files with description",
+					default: false,
+				})
+				.option("specificDir", {
+					type: "string",
+					describe: "Specific directory to document",
+					default: ".",
+				});
+		},
+		async (argv) => {
+			const outputFile = argv.output || getDefaultFilename();
+			try {
+				await generateDocs(outputFile, argv.includeBin, argv.specificDir);
+				console.log(`FlatRepo generated successfully at: ${outputFile}`);
+			} catch (error) {
+				console.error("Error generating documentation:", error);
+				process.exit(1);
+			}
+		}
+	)
+	.strict()
+	.help()
+	.parse();

--- a/dist/index.js
+++ b/dist/index.js
@@ -2,130 +2,117 @@ import { glob } from "glob";
 import * as fs from "fs/promises";
 import * as path from "path";
 import { stringify } from "yaml";
-import { BINARY_EXTENSIONS, EXTENSION_TO_LANGUAGE, getBinaryFileType, } from "./utils/file-types.js";
-import { DEFAULT_IGNORE_PATTERNS, getGitignorePatterns, shouldIgnoreFile, } from "./utils/gitignore.js";
+import { BINARY_EXTENSIONS, EXTENSION_TO_LANGUAGE, getBinaryFileType } from "./utils/file-types.js";
+import { DEFAULT_IGNORE_PATTERNS, getGitignorePatterns, shouldIgnoreFile } from "./utils/gitignore.js";
 function getLanguageFromExtension(extension) {
-    return EXTENSION_TO_LANGUAGE[extension] || "";
+	return EXTENSION_TO_LANGUAGE[extension] || "";
 }
-async function getProjectFiles(outputPath, includeBin, directory) {
-    const files = [];
-    const gitignorePatterns = await getGitignorePatterns();
-    const ignorePatterns = [
-        ...DEFAULT_IGNORE_PATTERNS,
-        ...gitignorePatterns,
-        outputPath,
-    ];
-    console.log("Patrones ignorados:", ignorePatterns);
-    try {
-        const matches = await glob(`${directory}/**/*.*`, {
-            dot: true,
-            nodir: true,
-        });
-        for (const match of matches) {
-            if (match === outputPath)
-                continue;
-            if (shouldIgnoreFile(match, gitignorePatterns))
-                continue;
-            try {
-                const stat = await fs.stat(match);
-                const extension = path.extname(match).toLowerCase();
-                if (stat.isFile()) {
-                    if (BINARY_EXTENSIONS.has(extension)) {
-                        if (includeBin) {
-                            files.push({
-                                path: match,
-                                content: `(Archivo binario de ${getBinaryFileType(extension)})`,
-                                extension,
-                                isBinary: true,
-                            });
-                        }
-                    }
-                    else {
-                        const content = await fs.readFile(match, "utf-8");
-                        files.push({
-                            path: match,
-                            content,
-                            extension,
-                            isBinary: false,
-                        });
-                    }
-                }
-            }
-            catch (error) {
-                console.warn(`Advertencia: No se pudo procesar ${match}:`, error);
-            }
-        }
-    }
-    catch (error) {
-        throw new Error(`Error al buscar archivos: ${error}`);
-    }
-    return files;
+async function getProjectFiles(outputPath, includeBin, specificDir) {
+	const files = [];
+	const gitignorePatterns = await getGitignorePatterns();
+	const ignorePatterns = [...DEFAULT_IGNORE_PATTERNS, ...gitignorePatterns, outputPath];
+	console.log("Patrones ignorados:", ignorePatterns);
+	try {
+		const matches = await glob(`${specificDir}/**/*.*`, {
+			dot: true,
+			nodir: true,
+		});
+		for (const match of matches) {
+			if (match === outputPath) continue;
+			if (shouldIgnoreFile(match, gitignorePatterns)) continue;
+			try {
+				const stat = await fs.stat(match);
+				const extension = path.extname(match).toLowerCase();
+				if (stat.isFile()) {
+					if (BINARY_EXTENSIONS.has(extension)) {
+						if (includeBin) {
+							files.push({
+								path: match,
+								content: `(Archivo binario de ${getBinaryFileType(extension)})`,
+								extension,
+								isBinary: true,
+							});
+						}
+					} else {
+						const content = await fs.readFile(match, "utf-8");
+						files.push({
+							path: match,
+							content,
+							extension,
+							isBinary: false,
+						});
+					}
+				}
+			} catch (error) {
+				console.warn(`Advertencia: No se pudo procesar ${match}:`, error);
+			}
+		}
+	} catch (error) {
+		throw new Error(`Error al buscar archivos: ${error}`);
+	}
+	return files;
 }
 function calculateStats(files) {
-    const stats = {
-        totalFiles: files.length,
-        totalLines: 0,
-        languages: {},
-        fileTypes: {},
-    };
-    for (const file of files) {
-        stats.totalLines += file.content.split("\n").length;
-        stats.fileTypes[file.extension] =
-            (stats.fileTypes[file.extension] || 0) + 1;
-        const language = getLanguageFromExtension(file.extension);
-        if (language) {
-            stats.languages[language] = (stats.languages[language] || 0) + 1;
-        }
-    }
-    return stats;
+	const stats = {
+		totalFiles: files.length,
+		totalLines: 0,
+		languages: {},
+		fileTypes: {},
+	};
+	for (const file of files) {
+		stats.totalLines += file.content.split("\n").length;
+		stats.fileTypes[file.extension] = (stats.fileTypes[file.extension] || 0) + 1;
+		const language = getLanguageFromExtension(file.extension);
+		if (language) {
+			stats.languages[language] = (stats.languages[language] || 0) + 1;
+		}
+	}
+	return stats;
 }
 function generateHeader(files, stats) {
-    const pkgFile = files.find((f) => f.path === "package.json");
-    const pkgData = pkgFile ? JSON.parse(pkgFile.content) : {};
-    const header = {
-        repository: {
-            name: pkgData.name || path.basename(process.cwd()),
-            owner: "unknown",
-            url: "",
-        },
-        generated: {
-            timestamp: new Date().toISOString(),
-            tool: "FlatRepo",
-        },
-        statistics: stats,
-    };
-    return `---\n${stringify(header)}---\n\n`;
+	const pkgFile = files.find((f) => f.path === "package.json");
+	const pkgData = pkgFile ? JSON.parse(pkgFile.content) : {};
+	const header = {
+		repository: {
+			name: pkgData.name || path.basename(process.cwd()),
+			owner: "unknown",
+			url: "",
+		},
+		generated: {
+			timestamp: new Date().toISOString(),
+			tool: "FlatRepo",
+		},
+		statistics: stats,
+	};
+	return `---\n${stringify(header)}---\n\n`;
 }
 function formatFileContent(file) {
-    const language = getLanguageFromExtension(file.extension);
-    let content = `===  ${file.path}\n`;
-    content += `\`\`\`${language}\n`;
-    content += file.content;
-    if (!file.content.endsWith("\n"))
-        content += "\n";
-    content += "```\n";
-    content += `=== EOF: ${file.path}\n\n`;
-    return content;
+	const language = getLanguageFromExtension(file.extension);
+	let content = `===  ${file.path}\n`;
+	content += `\`\`\`${language}\n`;
+	content += file.content;
+	if (!file.content.endsWith("\n")) content += "\n";
+	content += "```\n";
+	content += `=== EOF: ${file.path}\n\n`;
+	return content;
 }
 function generateMarkdown(files, stats) {
-    const header = generateHeader(files, stats);
-    const content = files.map(formatFileContent).join("");
-    return header + content;
+	const header = generateHeader(files, stats);
+	const content = files.map(formatFileContent).join("");
+	return header + content;
 }
 // Main function
-export async function generateDocs(outputPath, includeBin = false, directory = ".") {
-    try {
-        const files = await getProjectFiles(outputPath, includeBin, directory);
-        const stats = calculateStats(files);
-        const markdown = generateMarkdown(files, stats);
-        await fs.writeFile(outputPath, markdown, "utf-8");
-    }
-    catch (error) {
-        if (error instanceof Error) {
-            throw new Error(`Failed to generate documentation: ${error.message}`);
-        }
-        else {
-            throw new Error("Failed to generate documentation: An unknown error occurred");
-        }
-    }
+export async function generateDocs(outputPath, includeBin = false, specificDir = ".") {
+	try {
+		const files = await getProjectFiles(outputPath, includeBin, specificDir);
+		const stats = calculateStats(files);
+		const markdown = generateMarkdown(files, stats);
+		await fs.writeFile(outputPath, markdown, "utf-8");
+	} catch (error) {
+		if (error instanceof Error) {
+			throw new Error(`Failed to generate documentation: ${error.message}`);
+		} else {
+			throw new Error("Failed to generate documentation: An unknown error occurred");
+		}
+	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "flatrepo",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "flatrepo",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
         "glob": "^11.0.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -19,6 +19,7 @@ function getDefaultFilename(): string {
 interface Arguments {
   output?: string;
   includeBin?: boolean;
+  specificDir?: string;
 }
 
 yargs(hideBin(process.argv))
@@ -37,7 +38,7 @@ yargs(hideBin(process.argv))
         describe: 'Include binary files with description',
         default: false
       })
-      .option('dir', {
+      .option('specificDir', {
         type: 'string',
         describe: 'Specific directory to document',
         default: '.'
@@ -46,7 +47,7 @@ yargs(hideBin(process.argv))
     async (argv) => {
       const outputFile = argv.output || getDefaultFilename();
       try {
-        await generateDocs(outputFile, argv.includeBin, argv.dir as string);
+        await generateDocs(outputFile, argv.includeBin, argv.specificDir as string);
         console.log(`FlatRepo generated successfully at: ${outputFile}`);
       } catch (error) {
         console.error('Error generating documentation:', error);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -12,7 +12,7 @@ function getDefaultFilename(): string {
   const hours = String(now.getHours()).padStart(2, '0');
   const minutes = String(now.getMinutes()).padStart(2, '0');
   const seconds = String(now.getSeconds()).padStart(2, '0');
-  
+
   return `flatrepo_${year}${month}${day}${hours}${minutes}${seconds}.md`;
 }
 
@@ -36,12 +36,17 @@ yargs(hideBin(process.argv))
         type: 'boolean',
         describe: 'Include binary files with description',
         default: false
+      })
+      .option('dir', {
+        type: 'string',
+        describe: 'Specific directory to document',
+        default: '.'
       });
     },
     async (argv) => {
       const outputFile = argv.output || getDefaultFilename();
       try {
-        await generateDocs(outputFile, argv.includeBin);
+        await generateDocs(outputFile, argv.includeBin, argv.dir as string);
         console.log(`FlatRepo generated successfully at: ${outputFile}`);
       } catch (error) {
         console.error('Error generating documentation:', error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,140 +3,163 @@ import * as fs from "fs/promises";
 import * as path from "path";
 import { stringify } from "yaml";
 import { FileInfo, RepoStats, PackageJson } from "./types/index.js";
-import { BINARY_EXTENSIONS, EXTENSION_TO_LANGUAGE, getBinaryFileType } from "./utils/file-types.js";
-import { DEFAULT_IGNORE_PATTERNS, getGitignorePatterns, shouldIgnoreFile } from "./utils/gitignore.js";
+import {
+  BINARY_EXTENSIONS,
+  EXTENSION_TO_LANGUAGE,
+  getBinaryFileType,
+} from "./utils/file-types.js";
+import {
+  DEFAULT_IGNORE_PATTERNS,
+  getGitignorePatterns,
+  shouldIgnoreFile,
+} from "./utils/gitignore.js";
 
 function getLanguageFromExtension(extension: string): string {
-	return EXTENSION_TO_LANGUAGE[extension] || "";
+  return EXTENSION_TO_LANGUAGE[extension] || "";
 }
 
-async function getProjectFiles(outputPath: string, includeBin: boolean): Promise<FileInfo[]> {
-	const files: FileInfo[] = [];
+async function getProjectFiles(
+  outputPath: string,
+  includeBin: boolean,
+  directory: string
+): Promise<FileInfo[]> {
+  const files: FileInfo[] = [];
 
-	const gitignorePatterns = await getGitignorePatterns();
+  const gitignorePatterns = await getGitignorePatterns();
 
-	const ignorePatterns = [...DEFAULT_IGNORE_PATTERNS, ...gitignorePatterns, outputPath];
+  const ignorePatterns = [
+    ...DEFAULT_IGNORE_PATTERNS,
+    ...gitignorePatterns,
+    outputPath,
+  ];
 
-	console.log("Patrones ignorados:", ignorePatterns);
+  console.log("Patrones ignorados:", ignorePatterns);
 
-	try {
-		const matches = await glob("**/*.*", {
-			dot: true,
-			nodir: true,
-		});
+  try {
+    const matches = await glob(`${directory}/**/*.*`, {
+      dot: true,
+      nodir: true,
+    });
 
-		for (const match of matches) {
-			if (match === outputPath) continue;
+    for (const match of matches) {
+      if (match === outputPath) continue;
 
-			if (shouldIgnoreFile(match, gitignorePatterns)) continue;
-			try {
-				const stat = await fs.stat(match);
-				const extension = path.extname(match).toLowerCase();
+      if (shouldIgnoreFile(match, gitignorePatterns)) continue;
+      try {
+        const stat = await fs.stat(match);
+        const extension = path.extname(match).toLowerCase();
 
-				if (stat.isFile()) {
-					if (BINARY_EXTENSIONS.has(extension)) {
-						if (includeBin) {
-							files.push({
-								path: match,
-								content: `(Archivo binario de ${getBinaryFileType(extension)})`,
-								extension,
-								isBinary: true,
-							});
-						}
-					} else {
-						const content = await fs.readFile(match, "utf-8");
-						files.push({
-							path: match,
-							content,
-							extension,
-							isBinary: false,
-						});
-					}
-				}
-			} catch (error) {
-				console.warn(`Advertencia: No se pudo procesar ${match}:`, error);
-			}
-		}
-	} catch (error) {
-		throw new Error(`Error al buscar archivos: ${error}`);
-	}
+        if (stat.isFile()) {
+          if (BINARY_EXTENSIONS.has(extension)) {
+            if (includeBin) {
+              files.push({
+                path: match,
+                content: `(Archivo binario de ${getBinaryFileType(extension)})`,
+                extension,
+                isBinary: true,
+              });
+            }
+          } else {
+            const content = await fs.readFile(match, "utf-8");
+            files.push({
+              path: match,
+              content,
+              extension,
+              isBinary: false,
+            });
+          }
+        }
+      } catch (error) {
+        console.warn(`Advertencia: No se pudo procesar ${match}:`, error);
+      }
+    }
+  } catch (error) {
+    throw new Error(`Error al buscar archivos: ${error}`);
+  }
 
-	return files;
+  return files;
 }
 
 function calculateStats(files: FileInfo[]): RepoStats {
-	const stats: RepoStats = {
-		totalFiles: files.length,
-		totalLines: 0,
-		languages: {},
-		fileTypes: {},
-	};
+  const stats: RepoStats = {
+    totalFiles: files.length,
+    totalLines: 0,
+    languages: {},
+    fileTypes: {},
+  };
 
-	for (const file of files) {
-		stats.totalLines += file.content.split("\n").length;
+  for (const file of files) {
+    stats.totalLines += file.content.split("\n").length;
 
-		stats.fileTypes[file.extension] = (stats.fileTypes[file.extension] || 0) + 1;
+    stats.fileTypes[file.extension] =
+      (stats.fileTypes[file.extension] || 0) + 1;
 
-		const language = getLanguageFromExtension(file.extension);
-		if (language) {
-			stats.languages[language] = (stats.languages[language] || 0) + 1;
-		}
-	}
+    const language = getLanguageFromExtension(file.extension);
+    if (language) {
+      stats.languages[language] = (stats.languages[language] || 0) + 1;
+    }
+  }
 
-	return stats;
+  return stats;
 }
 
 function generateHeader(files: FileInfo[], stats: RepoStats): string {
-	const pkgFile = files.find((f) => f.path === "package.json");
-	const pkgData: PackageJson = pkgFile ? JSON.parse(pkgFile.content) : {};
+  const pkgFile = files.find((f) => f.path === "package.json");
+  const pkgData: PackageJson = pkgFile ? JSON.parse(pkgFile.content) : {};
 
-	const header = {
-		repository: {
-			name: pkgData.name || path.basename(process.cwd()),
-			owner: "unknown",
-			url: "",
-		},
-		generated: {
-			timestamp: new Date().toISOString(),
-			tool: "FlatRepo",
-		},
-		statistics: stats,
-	};
+  const header = {
+    repository: {
+      name: pkgData.name || path.basename(process.cwd()),
+      owner: "unknown",
+      url: "",
+    },
+    generated: {
+      timestamp: new Date().toISOString(),
+      tool: "FlatRepo",
+    },
+    statistics: stats,
+  };
 
-	return `---\n${stringify(header)}---\n\n`;
+  return `---\n${stringify(header)}---\n\n`;
 }
 
 function formatFileContent(file: FileInfo): string {
-	const language = getLanguageFromExtension(file.extension);
-	let content = `===  ${file.path}\n`;
-	content += `\`\`\`${language}\n`;
-	content += file.content;
-	if (!file.content.endsWith("\n")) content += "\n";
-	content += "```\n";
-	content += `=== EOF: ${file.path}\n\n`;
-	return content;
+  const language = getLanguageFromExtension(file.extension);
+  let content = `===  ${file.path}\n`;
+  content += `\`\`\`${language}\n`;
+  content += file.content;
+  if (!file.content.endsWith("\n")) content += "\n";
+  content += "```\n";
+  content += `=== EOF: ${file.path}\n\n`;
+  return content;
 }
 
 function generateMarkdown(files: FileInfo[], stats: RepoStats): string {
-	const header = generateHeader(files, stats);
-	const content = files.map(formatFileContent).join("");
-	return header + content;
+  const header = generateHeader(files, stats);
+  const content = files.map(formatFileContent).join("");
+  return header + content;
 }
 
 // Main function
-export async function generateDocs(outputPath: string, includeBin: boolean = false): Promise<void> {
-	try {
-		const files = await getProjectFiles(outputPath, includeBin);
-		const stats = calculateStats(files);
-		const markdown = generateMarkdown(files, stats);
-		await fs.writeFile(outputPath, markdown, "utf-8");
-	} catch (error: unknown) {
-		if (error instanceof Error) {
-			throw new Error(`Failed to generate documentation: ${error.message}`);
-		} else {
-			throw new Error("Failed to generate documentation: An unknown error occurred");
-		}
-	}
+export async function generateDocs(
+  outputPath: string,
+  includeBin: boolean = false,
+  directory: string = "."
+): Promise<void> {
+  try {
+    const files = await getProjectFiles(outputPath, includeBin, directory);
+    const stats = calculateStats(files);
+    const markdown = generateMarkdown(files, stats);
+    await fs.writeFile(outputPath, markdown, "utf-8");
+  } catch (error: unknown) {
+    if (error instanceof Error) {
+      throw new Error(`Failed to generate documentation: ${error.message}`);
+    } else {
+      throw new Error(
+        "Failed to generate documentation: An unknown error occurred"
+      );
+    }
+  }
 }
 
 export { FileInfo, RepoStats };

--- a/src/index.ts
+++ b/src/index.ts
@@ -21,7 +21,7 @@ function getLanguageFromExtension(extension: string): string {
 async function getProjectFiles(
   outputPath: string,
   includeBin: boolean,
-  directory: string
+  specificDir: string
 ): Promise<FileInfo[]> {
   const files: FileInfo[] = [];
 
@@ -36,7 +36,7 @@ async function getProjectFiles(
   console.log("Patrones ignorados:", ignorePatterns);
 
   try {
-    const matches = await glob(`${directory}/**/*.*`, {
+    const matches = await glob(`${specificDir}/**/*.*`, {
       dot: true,
       nodir: true,
     });
@@ -91,8 +91,7 @@ function calculateStats(files: FileInfo[]): RepoStats {
   for (const file of files) {
     stats.totalLines += file.content.split("\n").length;
 
-    stats.fileTypes[file.extension] =
-      (stats.fileTypes[file.extension] || 0) + 1;
+		stats.fileTypes[file.extension] = (stats.fileTypes[file.extension] || 0) + 1;
 
     const language = getLanguageFromExtension(file.extension);
     if (language) {
@@ -144,10 +143,10 @@ function generateMarkdown(files: FileInfo[], stats: RepoStats): string {
 export async function generateDocs(
   outputPath: string,
   includeBin: boolean = false,
-  directory: string = "."
+  specificDir: string = "."
 ): Promise<void> {
   try {
-    const files = await getProjectFiles(outputPath, includeBin, directory);
+    const files = await getProjectFiles(outputPath, includeBin, specificDir);
     const stats = calculateStats(files);
     const markdown = generateMarkdown(files, stats);
     await fs.writeFile(outputPath, markdown, "utf-8");


### PR DESCRIPTION
# Add directory-specific documentation option

## Description
Added a new `--dir` option to the CLI that allows users to generate documentation for a specific directory within the repository. This enhancement provides more flexibility when users need to focus on documenting particular sections of their codebase.

## Features
- New `--dir` CLI option to specify target directory
- Default behavior (documenting entire repository) remains unchanged
- Compatible with existing options like `--include-bin`

## Example Usage
```bash
flatrepo myrepo.md --dir src